### PR TITLE
Update firebase/php-jwt version to be compatible with Laravel Passport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "firebase/php-jwt": "^5.2",
+        "firebase/php-jwt": "^6.0",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
Laravel passport v10 (recommended version for Laravel 8+) utilizes v6 of firebase/php-jwt making this socialite plugin incompatible. This patch enables compatibility with both packages.