### PR TITLE
handle AzureADB2C user name empty values

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -188,8 +188,8 @@ class Provider extends AbstractProvider
     {
         return (new User)->setRaw($user)->map([
             'id'       => $user['sub'],
-            'nickname' => $user['name'],
-            'name'     => $user['name'],
+            'nickname' => $user['name'] ?? null,
+            'name'     => $user['name'] ?? null,
             'email'    => $user['emails'][0] ?? $user['email'] ?? null,
         ]);
     }


### PR DESCRIPTION
Handle null values for 'nickname' and 'name' in AzureADB2C Provider

Updated the `mapUserToObject` method to handle null values for 'nickname' and 'name' attributes when mapping user data. This ensures compatibility with B2C tenants that may not provide a user name.