### PR TITLE
feat: added function to get the user object by the id_token returned through the getAccessTokenResponse() function

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -117,19 +117,7 @@ class Provider extends AbstractProvider
     {
         return $this->getOpenIdConfiguration()->token_endpoint;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getUserByToken($token)
-    {
-        $this->setRedirectUrl();
-
-        $claims = $this->validateIdToken($token);
-
-        return $this->mapUserToObject($claims);
-    }
-
+    
     /**
      * Additional implementation to get user claims from id_token.
      *

--- a/Provider.php
+++ b/Provider.php
@@ -121,9 +121,13 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected function getUserByToken($token)
+    public function getUserByToken($token)
     {
-        // no implementation required because Azure AD B2C doesn't return access_token
+        $this->setRedirectUrl();
+
+        $claims = $this->validateIdToken($token);
+
+        return $this->mapUserToObject($claims);
     }
 
     /**


### PR DESCRIPTION
I'm currently integrating with Azure B2C where we save the data returned by Azure in a session storage.
In this case i need to be able to get the user data after the initial authentication.
Currently i get the access token and save it by using the getAccessTokenResponse function.
With this change you can call the user by calling with the id_token returned by the getAccessTokenResponse function.