### PR TITLE
feat: added getAccessTokenResponse() function and refreshToken() function

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -117,6 +117,18 @@ class Provider extends AbstractProvider
     {
         return $this->getOpenIdConfiguration()->token_endpoint;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserByToken($token)
+    {
+        $this->setRedirectUrl();
+
+        $claims = $this->validateIdToken($token);
+
+        return $this->mapUserToObject($claims);
+    }
     
     /**
      * Additional implementation to get user claims from id_token.

--- a/Provider.php
+++ b/Provider.php
@@ -117,19 +117,7 @@ class Provider extends AbstractProvider
     {
         return $this->getOpenIdConfiguration()->token_endpoint;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getUserByToken($token)
-    {
-        $this->setRedirectUrl();
-
-        $claims = $this->validateIdToken($token);
-
-        return $this->mapUserToObject($claims);
-    }
-
+    
     /**
      * Additional implementation to get user claims from id_token.
      *

--- a/Provider.php
+++ b/Provider.php
@@ -146,6 +146,22 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getRefreshTokenResponse($refreshToken);
+
+        return new Token(
+            Arr::get($response, 'id_token'),
+            Arr::get($response, 'refresh_token'),
+            Arr::get($response, 'id_token_expires_in'),
+            explode($this->scopeSeparator, Arr::get($response, 'scope', ''))
+        );
+    }
+
+
+    /**
      * validate id_token
      * - signature validation using firebase/jwt library.
      * - claims validation

--- a/Provider.php
+++ b/Provider.php
@@ -121,9 +121,13 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected function getUserByToken($token)
+    public function getUserByToken($token)
     {
-        // no implementation required because Azure AD B2C doesn't return access_token
+        $this->setRedirectUrl();
+
+        $claims = $this->validateIdToken($token);
+
+        return $this->mapUserToObject($claims);
     }
 
     /**

--- a/Provider.php
+++ b/Provider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Two\InvalidStateException;
+use Laravel\Socialite\Two\Token;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 


### PR DESCRIPTION
I'm currently integrating with Azure B2C where we save the data returned by Azure in a session storage.
In this case i need to be able to get the user data after the initial authentication.
Currently i get the access token and save it by using the getAccessTokenResponse function.
With this change you can call the user by calling with the id_token returned by the getAccessTokenResponse function.

Furthermore, the refreshToken from socialite dosn't work with the format of the response from azure.
Therefore I've also added the refreshToken function.